### PR TITLE
add pricing page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,7 @@ module.exports = {
     menu: [
       { name: 'Features', route: '/features' },
       { name: 'Download', route: '/download' },
+      { name: 'Pricing', route: '/pricing' },
       { name: 'Docs', route: '/docs' },
       { name: 'Login', route: '/login' },
       { name: 'Sign up', route: '/signup' },

--- a/src/components/Switch/Switch.module.scss
+++ b/src/components/Switch/Switch.module.scss
@@ -1,0 +1,59 @@
+$dark-blue: #35bcf9;
+$light-blue: #e8f8ff;
+$height: 1.9rem;
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: calc(#{$height} * 1.93);
+  height: $height;
+  margin-bottom: 0;
+
+  & input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+
+    &:checked + .switch__slider {
+      background-color: $dark-blue;
+
+      &:before {
+        background-color: $light-blue;
+        transform: translateX(26px);
+      }
+    }
+
+    &:focus + .switch__slider {
+      box-shadow: 0 0 1px #2196f3;
+    }
+  }
+
+  &__slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: $light-blue;
+    transition: 0.4s;
+
+    &:before {
+      position: absolute;
+      content: '';
+      height: calc(#{$height} / 1.4);
+      width: calc(#{$height} / 1.4);
+      left: calc(#{$height} / 6.2);
+      bottom: calc(#{$height} / 6.2);
+      background-color: $dark-blue;
+      transition: 0.4s;
+    }
+
+    &_round {
+      border-radius: $height;
+      &:before {
+        border-radius: 50%;
+      }
+    }
+  }
+}

--- a/src/components/Switch/index.js
+++ b/src/components/Switch/index.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react'
+
+import './Switch.module.scss'
+
+export default class Switch extends Component {
+  render() {
+    return (
+      <label styleName="switch">
+        <input onClick={this.props.handlesClick} type="checkbox" />
+        <span styleName="switch__slider switch__slider_round" />
+      </label>
+    )
+  }
+}

--- a/src/components/Table/PricingTable.js
+++ b/src/components/Table/PricingTable.js
@@ -81,10 +81,9 @@ export default class PricingTable extends Component {
       array.map(elem => {
         if (_.find(seen, ['name', elem.name])) {
           const index = _.findIndex(seen, ['name', elem.name])
-          seen[index].value = [...seen[index].value, elem.value]
-          return
+          return seen[index].value = [...seen[index].value, elem.value]
         }
-        seen = [...seen, { ...elem, value: [elem.value] }]
+        return seen = [...seen, { ...elem, value: [elem.value] }]
       })
 
       return seen

--- a/src/components/Table/PricingTable.js
+++ b/src/components/Table/PricingTable.js
@@ -1,0 +1,113 @@
+import React, { Component } from 'react'
+import _ from 'lodash'
+
+import './Table.module.scss'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheck, faMinus } from '@fortawesome/free-solid-svg-icons'
+import Button from '../Button'
+
+const calcDiscount = (price, discountBase) => {
+  const discounted = (discountBase / 100) * price
+  return price - discounted
+}
+
+const PricingPlan = ({ title, price, handler, discountBase }) => {
+  const yearlyPrice = price * 12
+
+  return (
+    <th styleName="plan">
+      <p styleName="plan__title">{title}</p>
+      <p styleName="plan__price">
+        {price ? (
+          <>
+            ${calcDiscount(price, discountBase)}
+            <span>/month</span>
+          </>
+        ) : (
+          'Free'
+        )}
+      </p>
+      <p styleName="plan__discount">
+        {discountBase > 0 && (
+          <>
+            <span>${yearlyPrice}/Year</span>$
+            {calcDiscount(yearlyPrice, discountBase)}/Year
+          </>
+        )}
+      </p>
+      {handler && (
+        <Button className="mb-3" onClick={handler}>
+          Try it
+        </Button>
+      )}
+    </th>
+  )
+}
+
+const PricingFeature = ({ name = 'feature', value = [] }) => {
+  return (
+    <tr styleName="feature">
+      <td styleName="feature__name">{name}</td>
+      {value.map((item, i) => {
+        const elem = _.isBoolean(item) ? (
+          <FontAwesomeIcon icon={item ? faCheck : faMinus} />
+        ) : (
+          item
+        )
+        return (
+          <td styleName="feature__value" key={i}>
+            {elem}
+          </td>
+        )
+      })}
+    </tr>
+  )
+}
+
+export default class PricingTable extends Component {
+  render() {
+    const { plans } = this.props
+
+    const planFeatures = plans.reduce((features, nextPlan) => {
+      if (!features) {
+        return nextPlan.features
+      }
+      return [...features, ...nextPlan.features]
+    }, [])
+
+    const mergeFeatures = array => {
+      let seen = []
+      array.map(elem => {
+        if (_.find(seen, ['name', elem.name])) {
+          const index = _.findIndex(seen, ['name', elem.name])
+          seen[index].value = [...seen[index].value, elem.value]
+          return
+        }
+        seen = [...seen, { ...elem, value: [elem.value] }]
+      })
+
+      return seen
+    }
+
+    let groupedFeatures = mergeFeatures(planFeatures)
+
+    return (
+      <table styleName="table pricing-table">
+        <thead styleName="thead">
+          <tr>
+            <th> </th>
+            {plans.map((plan, i) => {
+              return <PricingPlan key={i} {...plan} />
+            })}
+          </tr>
+        </thead>
+        <tbody styleName="tbody">
+          {groupedFeatures.map((feature, i) => {
+            return <PricingFeature key={i} {...feature} />
+          })}
+        </tbody>
+      </table>
+    )
+  }
+}

--- a/src/components/Table/PricingTable.js
+++ b/src/components/Table/PricingTable.js
@@ -19,13 +19,11 @@ const PricingPlan = ({ title, price, handler, discountBase }) => {
     <th styleName="plan">
       <p styleName="plan__title">{title}</p>
       <p styleName="plan__price">
-        {price ? (
+        {isNaN(price) ? (price) : (
           <>
             ${calcDiscount(price, discountBase)}
             <span>/month</span>
           </>
-        ) : (
-          'Free'
         )}
       </p>
       <p styleName="plan__discount">
@@ -37,8 +35,8 @@ const PricingPlan = ({ title, price, handler, discountBase }) => {
         )}
       </p>
       {handler && (
-        <Button className="mb-3" onClick={handler}>
-          Try it
+        <Button className="mb-3" onClick={handler} disabled={title === 'Beta' ? false : true}>
+          Sign up
         </Button>
       )}
     </th>

--- a/src/components/Table/Table.module.scss
+++ b/src/components/Table/Table.module.scss
@@ -1,0 +1,206 @@
+$border-color: #dddddd;
+$border-size: 1px;
+$corner-radius: 15px;
+
+.table {
+  width: 100%;
+  text-align: center;
+  table-layout: fixed;
+  background-color: white;
+}
+
+.pricing-table {
+  margin-bottom: 7rem;
+  position: relative;
+
+  .plan {
+    position: relative;
+    padding: 1rem 0.5rem;
+    vertical-align: baseline;
+
+    &__title {
+      font-size: 1.3rem;
+      font-weight: 400;
+      margin-bottom: 0;
+    }
+
+    &__price {
+      color: #35bcf9;
+      font-size: 2.3rem;
+      margin-bottom: 0.5rem;
+
+      span {
+        font-size: 1rem;
+        font-weight: 500;
+      }
+    }
+
+    &__discount {
+      span {
+        margin-bottom: 0.2rem;
+        font-size: 0.8rem;
+        display: block;
+        color: #acb8bd;
+        text-decoration: line-through;
+        margin-right: 0.3rem;
+      }
+    }
+
+    button {
+      text-transform: capitalize;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+      font-size: 0.9rem;
+    }
+
+    &:after {
+      content: '';
+      height: 100%;
+      width: calc(100% + 1px);
+      left: 0;
+      top: 0;
+      border-color: $border-color;
+      border-style: solid;
+      border-width: $border-size $border-size 0 $border-size;
+      position: absolute;
+      background-color: inherit;
+      pointer-events: none;
+    }
+
+    &:nth-child(2):after {
+      border-top-left-radius: $corner-radius;
+    }
+
+    &:last-child:after {
+      border-top-right-radius: $corner-radius;
+    }
+  }
+
+  .feature {
+    position: relative;
+    $dark-blue: #35bcf9;
+
+    &__name {
+      text-align: left;
+      background-color: $dark-blue;
+      color: white;
+      font-size: 0.9rem;
+      font-weight: 500;
+      padding: 0.7rem 1rem;
+      position: relative;
+    }
+
+    &__value {
+      position: relative;
+      color: $dark-blue;
+      font-weight: bold;
+      font-size: 1.3rem;
+      border-left: $border-size solid $border-color;
+      border-right: $border-size solid $border-color;
+
+      svg {
+        font-size: 1.15rem;
+      }
+    }
+
+    &:nth-child(odd) .feature__name {
+      background-color: #3eb0e4;
+    }
+
+    &:first-child > .feature__name:before,
+    &:last-child > .feature__name:after {
+      content: '';
+      height: 1.5rem;
+      width: 100%;
+      background-color: $dark-blue;
+      position: absolute;
+      left: 0;
+    }
+
+    &:first-child > .feature__name:first-child:before {
+      top: -1.5rem;
+      border-top-left-radius: $corner-radius;
+    }
+
+    &:last-child > .feature__name:first-child:after {
+      bottom: -1.5rem;
+      border-bottom-left-radius: $corner-radius;
+    }
+
+    &:last-child > .feature__value:after {
+      content: '';
+      height: calc(100% + 2.4rem);
+      width: calc(100% + 1px);
+      background-color: inherit;
+      position: absolute;
+      left: 0;
+      top: 0;
+      border-color: $border-color;
+      border-style: solid;
+      border-width: 0 $border-size $border-size 0;
+    }
+
+    &:last-child > td:nth-child(2) {
+      border: none;
+
+      &:after {
+        border-left: $border-color $border-size solid;
+        border-bottom-left-radius: $corner-radius;
+      }
+    }
+
+    &:last-child > td:last-child {
+      border: none;
+
+      &:after {
+        border-bottom-right-radius: $corner-radius;
+      }
+    }
+  }
+
+  @media screen and (min-width: 600px) {
+    margin-bottom: 9rem;
+    .plan__price span {
+      display: block;
+    }
+  }
+
+  @media screen and (min-width: 768px) {
+    button {
+      width: 80%;
+      max-width: 9rem;
+    }
+    .feature__name {
+      font-size: 1rem;
+    }
+  }
+
+  @media screen and (min-width: 992px) {
+    .plan__price {
+      font-size: 2.9rem;
+      span {
+        font-size: 1.4rem;
+        display: inline;
+      }
+    }
+    .plan__title {
+      font-size: 1.5rem;
+    }
+  }
+}
+
+.thead {
+  position: relative;
+}
+
+.tbody {
+  padding: 0.7rem 0;
+
+  tr {
+    position: relative;
+
+    &:nth-child(odd) {
+      background-color: #e8f8ff;
+    }
+  }
+}

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -1,0 +1,174 @@
+import React, { Component } from 'react'
+
+import '../styles/pricing.module.scss'
+
+import SEO from '../components/seo'
+import PricingTable from '../components/Table/PricingTable'
+import Switch from '../components/Switch'
+
+export default class PricingPage extends Component {
+  state = {
+    width: undefined,
+    discountBase: 0,
+  }
+
+  toggleDiscount = () => {
+    const { discountBase } = this.state
+
+    discountBase === 0
+      ? this.setState({ discountBase: 20 })
+      : this.setState({ discountBase: 0 })
+  }
+
+  componentWillMount = () => {
+    this.updateDimensions()
+  }
+
+  componentDidMount = () => {
+    window.addEventListener('resize', this.updateDimensions)
+  }
+
+  componentWillUnmount = () => {
+    window.removeEventListener('resize', this.updateDimensions)
+  }
+
+  updateDimensions = () => {
+    var w = window,
+      d = document,
+      documentElement = d.documentElement,
+      body = d.getElementsByTagName('body')[0],
+      width = w.innerWidth || documentElement.clientWidth || body.clientWidth
+
+    this.setState({ width })
+  }
+
+  render() {
+    const { discountBase } = this.state
+    const plans = [
+      {
+        title: 'Basic',
+        price: '',
+        handler: () => alert('basic'),
+        features: [
+          {
+            name: 'HTTP/TCP tunnels on random URLs/ports',
+            value: true,
+          },
+          {
+            name: 'Custom Subdomains',
+            value: true,
+          },
+          {
+            name: 'Reserved Domains',
+            value: true,
+          },
+          {
+            name: 'Google Apps SSO',
+            value: true,
+          },
+          {
+            name: 'Whitelabel Domains',
+            value: false,
+          },
+          {
+            name: 'Priority Support',
+            value: false,
+          },
+        ],
+      },
+      {
+        title: 'Pro',
+        price: 5,
+        discountBase: discountBase,
+        handler: () => alert('Pro'),
+        features: [
+          {
+            name: 'HTTP/TCP tunnels on random URLs/ports',
+            value: true,
+          },
+          {
+            name: 'Custom Subdomains',
+            value: true,
+          },
+          {
+            name: 'Reserved Domains',
+            value: true,
+          },
+          {
+            name: 'Google Apps SSO',
+            value: true,
+          },
+          {
+            name: 'Whitelabel Domains',
+            value: true,
+          },
+          {
+            name: 'Priority Support',
+            value: false,
+          },
+        ],
+      },
+      {
+        title: 'Business',
+        price: 8,
+        discountBase: discountBase,
+        handler: () => alert('Business'),
+        features: [
+          {
+            name: 'HTTP/TCP tunnels on random URLs/ports',
+            value: true,
+          },
+          {
+            name: 'Custom Subdomains',
+            value: true,
+          },
+          {
+            name: 'Reserved Domains',
+            value: true,
+          },
+          {
+            name: 'Google Apps SSO',
+            value: true,
+          },
+          {
+            name: 'Whitelabel Domains',
+            value: true,
+          },
+          {
+            name: 'Priority Support',
+            value: true,
+          },
+        ],
+      },
+    ]
+
+    return (
+      <>
+        <SEO title="Holepunch Features" />
+        <div className="container page__header">
+          <h2>Pricing</h2>
+          <p>
+            Making it more productive is a no-brainer. <br /> All paid plans
+            come with a 15-day money back guarantee.
+          </p>
+        </div>
+        <div className="container features">
+          <div styleName="yearly-widget">
+            Monthly Billing <Switch handlesClick={this.toggleDiscount} />{' '}
+            <span styleName="yearly-widget__highlight">
+              Yearly Billing
+              <span styleName="yearly-widget__badge">
+                Save {this.state.discountBase}%
+              </span>
+            </span>
+          </div>
+          {this.state.width < 600 ? (
+            plans.map((plan, i) => <PricingTable key={i} plans={[plan]} />)
+          ) : (
+            <PricingTable plans={plans} />
+          )}
+        </div>
+      </>
+    )
+  }
+}

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -54,96 +54,120 @@ export default class PricingPage extends Component {
     }
     const plans = [
       {
-        title: 'Basic',
-        price: '',
+        title: 'Beta',
+        price: 'Free',
         handler: navigateToBilling,
         features: [
           {
-            name: 'HTTP/TCP tunnels on random URLs/ports',
+            name: 'HTTP/HTTPS Support',
             value: true,
           },
           {
-            name: 'Custom Subdomains',
-            value: true,
+            name: 'TCP/UDP Support',
+            value: 'coming soon',
           },
           {
-            name: 'Reserved Domains',
-            value: true,
+            name: 'Custom/Reserved Subdomains',
+            value: 1,
           },
           {
-            name: 'Google Apps SSO',
-            value: true,
-          },
-          {
-            name: 'Whitelabel Domains',
+            name: 'Custom Domains',
             value: false,
           },
           {
-            name: 'Priority Support',
+            name: 'Punch Processes',
+            value: 2,
+          },
+          {
+            name: 'Ports per Process',
+            value: 'no limit',
+          },
+          {
+            name: 'Data Rate',
+            value: '1000kBps',
+          },
+          {
+            name: 'End-to-end TLS Tunnels',
+            value: true,
+          },
+        ],
+      },
+      {
+        title: 'Free',
+        price: 'Free',
+        discountBase: discountBase,
+        handler: navigateToBilling,
+        features: [
+          {
+            name: 'HTTP/HTTPS Support',
+            value: true,
+          },
+          {
+            name: 'TCP/UDP Support',
+            value: 'coming soon',
+          },
+          {
+            name: 'Custom/Reserved Subdomains',
             value: false,
+          },
+          {
+            name: 'Custom Domains',
+            value: false,
+          },
+          {
+            name: 'Punch Processes',
+            value: 1,
+          },
+          {
+            name: 'Ports per Process',
+            value: 'no limit',
+          },
+          {
+            name: 'Data Rate',
+            value: '100kBps',
+          },
+          {
+            name: 'End-to-end TLS Tunnels',
+            value: true,
           },
         ],
       },
       {
         title: 'Pro',
-        price: 5,
+        price: 'TBD',
         discountBase: discountBase,
         handler: navigateToBilling,
         features: [
           {
-            name: 'HTTP/TCP tunnels on random URLs/ports',
+            name: 'HTTP/HTTPS Support',
             value: true,
           },
           {
-            name: 'Custom Subdomains',
+            name: 'TCP/UDP Support',
+            value: 'coming soon',
+          },
+          {
+            name: 'Custom/Reserved Subdomains',
             value: true,
           },
           {
-            name: 'Reserved Domains',
-            value: true,
+            name: 'Custom Domains',
+            value: 'true',
           },
           {
-            name: 'Google Apps SSO',
-            value: true,
+            name: 'Punch Processes',
+            value: 'TBD',
           },
           {
-            name: 'Whitelabel Domains',
-            value: true,
+            name: 'Ports per Process',
+            value: 'no limit',
           },
           {
-            name: 'Priority Support',
-            value: false,
-          },
-        ],
-      },
-      {
-        title: 'Business',
-        price: 8,
-        discountBase: discountBase,
-        handler: navigateToBilling,
-        features: [
-          {
-            name: 'HTTP/TCP tunnels on random URLs/ports',
-            value: true,
+            name: 'Data Rate',
+            value: 'TBD',
           },
           {
-            name: 'Custom Subdomains',
-            value: true,
-          },
-          {
-            name: 'Reserved Domains',
-            value: true,
-          },
-          {
-            name: 'Google Apps SSO',
-            value: true,
-          },
-          {
-            name: 'Whitelabel Domains',
-            value: true,
-          },
-          {
-            name: 'Priority Support',
+            name: 'End-to-end TLS Tunnels',
             value: true,
           },
         ],
@@ -154,10 +178,10 @@ export default class PricingPage extends Component {
       <>
         <SEO title="Holepunch Features" />
         <div className="container page__header">
-          <h2>Pricing</h2>
+          <h2>Pick the plan that meets your needs</h2>
           <p>
-            Making it more productive is a no-brainer. <br /> All paid plans
-            come with a 15-day money back guarantee.
+            Simply sign up for a plan and then start sharing with the world. <br />
+            You can upgrade anytime.
           </p>
         </div>
         <div className="container features">

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { navigate } from 'gatsby'
 
 import '../styles/pricing.module.scss'
 
@@ -47,11 +48,15 @@ export default class PricingPage extends Component {
 
   render() {
     const { discountBase } = this.state
+    const navigateToBilling = () => {
+      navigate('/account/billing')
+      return
+    }
     const plans = [
       {
         title: 'Basic',
         price: '',
-        handler: () => alert('basic'),
+        handler: navigateToBilling,
         features: [
           {
             name: 'HTTP/TCP tunnels on random URLs/ports',
@@ -83,7 +88,7 @@ export default class PricingPage extends Component {
         title: 'Pro',
         price: 5,
         discountBase: discountBase,
-        handler: () => alert('Pro'),
+        handler: navigateToBilling,
         features: [
           {
             name: 'HTTP/TCP tunnels on random URLs/ports',
@@ -115,7 +120,7 @@ export default class PricingPage extends Component {
         title: 'Business',
         price: 8,
         discountBase: discountBase,
-        handler: () => alert('Business'),
+        handler: navigateToBilling,
         features: [
           {
             name: 'HTTP/TCP tunnels on random URLs/ports',

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -153,15 +153,17 @@ export default class PricingPage extends Component {
           </p>
         </div>
         <div className="container features">
-          <div styleName="yearly-widget">
-            Monthly Billing <Switch handlesClick={this.toggleDiscount} />{' '}
-            <span styleName="yearly-widget__highlight">
-              Yearly Billing
-              <span styleName="yearly-widget__badge">
-                Save {this.state.discountBase}%
+          {false && (
+            <div styleName="yearly-widget">
+              Monthly Billing <Switch handlesClick={this.toggleDiscount} />{' '}
+              <span styleName="yearly-widget__highlight">
+                Yearly Billing
+                <span styleName="yearly-widget__badge">
+                  Save {this.state.discountBase}%
+                </span>
               </span>
-            </span>
-          </div>
+            </div>
+          )}
           {this.state.width < 600 ? (
             plans.map((plan, i) => <PricingTable key={i} plans={[plan]} />)
           ) : (

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -33,11 +33,14 @@ export default class PricingPage extends Component {
   }
 
   updateDimensions = () => {
-    var w = window,
-      d = document,
-      documentElement = d.documentElement,
-      body = d.getElementsByTagName('body')[0],
+    let width
+    if (typeof window !== 'undefined') {
+      const w = window,
+        d = document,
+        documentElement = d.documentElement,
+        body = d.getElementsByTagName('body')[0]
       width = w.innerWidth || documentElement.clientWidth || body.clientWidth
+    }
 
     this.setState({ width })
   }

--- a/src/styles/pricing.module.scss
+++ b/src/styles/pricing.module.scss
@@ -1,0 +1,55 @@
+.yearly-widget {
+  font-size: 0.9rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 3.5rem;
+  margin-bottom: 1.5rem;
+
+  label {
+    margin: 0 1rem;
+  }
+
+  &__highlight {
+    color: #29bbfc;
+    font-weight: 600;
+    position: relative;
+  }
+
+  &__badge {
+    $arrow-size: 8px;
+    position: absolute;
+    right: 1rem;
+    top: -2.5rem;
+    font-size: 0.7rem;
+    padding: 0.2rem 0.4rem;
+    color: white;
+    font-weight: 600;
+    background-color: #71cef9;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 0;
+      border-right: $arrow-size solid transparent;
+      border-left: $arrow-size solid transparent;
+      border-top: $arrow-size solid #71cef9;
+      left: 5px;
+      bottom: -5px;
+    }
+
+    @media screen and (min-width: 600px) {
+      right: -4.7rem;
+      top: unset;
+
+      &::before {
+        left: -13px;
+        bottom: unset;
+        border-top: $arrow-size solid transparent;
+        border-bottom: $arrow-size solid transparent;
+        border-right: $arrow-size solid #71cef9;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pricing table breaks on a 600px viewpoint into a single 2 column plan. I would say this is okay but maybe we can change it to cover tablet completely as in some views it might feel a little bit squished. But this is with a 3 plan layout, if we need more plans we might want to break it up in other ways.

As for the price discount as we previously spoke I added the yearly comparison when the discount toggle is triggered.